### PR TITLE
Default pattern patch 1

### DIFF
--- a/lib/strsplit.js
+++ b/lib/strsplit.js
@@ -8,6 +8,11 @@ function strsplit(str, pattern, limit)
 {
 	var i, rv, last, match;
 
+	if (!pattern) {
+		pattern = /\s+/;
+		str = str.trim();
+	}
+
 	if (arguments.length < 3 || !limit)
 		return (str.split(pattern));
 

--- a/tests/strsplit.js
+++ b/tests/strsplit.js
@@ -44,3 +44,9 @@ mod_assert.deepEqual([ 'one', 'two three' ],
     strsplit('one two three', ' ', 2));
 mod_assert.deepEqual([ 'one', 'two\tthree' ],
     strsplit('one     two\tthree', /\s+/, 2));
+
+/* Test default pattern */
+mod_assert.deepEqual([ 'one', 'two', 'three', 'four' ],
+    strsplit('    one   two three\tfour  '));
+mod_assert.deepEqual([ 'one', 'two three\tfour' ],
+    strsplit('    one   two three\tfour  ', null, 2));


### PR DESCRIPTION
I tell the pattern to default to /\s+/ if not specified, to better match how split works in python.  I like python's implementation, which is also very simple to bash with `while read field1 field2 field3 ...; do foo; done`, because it will trim the string and split it.

given the string `'   field1 field2    field3\tfield4   '` you can see the example below with this patch.

python

``` python
>>> '   field1 field2    field3\tfield4   '.split()
['field1', 'field2', 'field3', 'field4']
>>> '   field1 field2    field3\tfield4   '.split(' ')
['', '', '', 'field1', 'field2', '', '', '', 'field3\tfield4', '', '', '']
>>> '   field1 field2    field3\tfield4   '.split(None, 1)
['field1', 'field2    field3\tfield4   ']
```

node

``` js
> strsplit('   field1 field2    field3\tfield4   ')
[ 'field1',
  'field2',
  'field3',
  'field4' ]
> strsplit('   field1 field2    field3\tfield4   ', ' ')
[ '',
  '',
  '',
  'field1',
  'field2',
  '',
  '',
  '',
  'field3\tfield4',
  '',
  '',
  '' ]
> strsplit('   field1 field2    field3\tfield4   ', null, 1)
[ 'field1 field2    field3\tfield4' ]
> strsplit('   field1 field2    field3\tfield4   ', null, 2)
[ 'field1', 'field2    field3\tfield4' ]
```

The only difference being that python is 0-indexed when splitting.

This patch will only change the result if the pattern argument is not supplied (or is `null`).
